### PR TITLE
Update to JSONAPI 1.0 spec.

### DIFF
--- a/lib/navis-adapter.js
+++ b/lib/navis-adapter.js
@@ -15,7 +15,7 @@ module.exports = CoreObject.extend({
     CoreObject.prototype.init.apply(this, arguments);
 
     if (!this.config) {
-      throw new SilentError('You must supply a config in deploy.json');
+      throw new SilentError('You must supply a config in deploy.js');
     }
 
     this.indexPrefix = this.config.prefix || '';
@@ -128,7 +128,7 @@ module.exports = CoreObject.extend({
           if (err) {
             reject(err);
           } else {
-            resolve(res.body.builds);
+            resolve(res.body.data);
           }
         });
     }.bind(this));
@@ -183,12 +183,12 @@ module.exports = CoreObject.extend({
 
   _formatUploadParams: function(value, key) {
     var params = {
-      builds: {
-        ref: key,
-        raw_index: value
-      },
-      ContentType: 'text/html',
-      CacheControl: 'max-age=0, no-cache'
+      data: {
+        attributes: {
+          ref: key,
+          raw_index: value
+        }
+      }
     };
 
     return params;
@@ -209,7 +209,7 @@ module.exports = CoreObject.extend({
 
   _revisionsList: function(revisions) {
     return revisions.map(function(rev) {
-      return rev.ref;
+      return rev.attributes.ref;
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-deploy-navis",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "ember-deploy adapter for navis.io",
   "repository": "",
   "engines": {


### PR DESCRIPTION
/cc @patrickberkeley.

One thing not handled here is printing error messages appropriately. For instance if you try to re-deploy an already activated build vs re-deploying an inactive build.
